### PR TITLE
Do not override container entrypoint since it's already set to `/valida-toolchain/valida-shell`

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,7 +12,7 @@ docker pull ghcr.io/lita-xyz/llvm-valida-releases/valida-build-container:v0.5.0-
 cd your-valida-project
 
 # Enter the container:
-docker run --platform linux/amd64 --entrypoint=/bin/bash -it --rm -v $(realpath .):/src ghcr.io/lita-xyz/llvm-valida-releases/valida-build-container:v0.5.0-alpha
+docker run --platform linux/amd64 -it --rm -v $(realpath .):/src ghcr.io/lita-xyz/llvm-valida-releases/valida-build-container:v0.5.0-alpha
 
 # You are now in a shell with the valida rust toolchain installed!
 ```


### PR DESCRIPTION
Depends on https://github.com/lita-xyz/valida-docker/pull/7